### PR TITLE
Not found transcation document

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -87,6 +87,8 @@ class PreFindOne {
         return tid;
 
       case 'canceled':
+        // TODO :  비정상 상태로 인하여 canceled가 남는 경우 transcation document는 제거 되지 않고 현재 남겨져 있다.
+        debug('already canceled. ignore __t');
         return tid;
     }
   }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -85,6 +85,9 @@ class PreFindOne {
       case 'committed':
         debug('already committed. ignore __t');
         return tid;
+
+      case 'canceled':
+        return tid;
     }
   }
 

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -107,15 +107,10 @@ export class Transaction extends events.EventEmitter {
         if (participant.doc.isNew) return participant.doc['__t'] = undefined;
         return await participant.doc.update({$unset: {__t: ''}}, { w: 1 }, undefined).exec();
       });
+      await this.transaction.remove();
     } catch (e) {
       debug('[warning] removing __t has been failed');
-      return this.resetTransaction();
     }
-    await this.transaction.remove();
-    return this.resetTransaction();
-  }
-
-  private async resetTransaction(): Promise<void> {
     this.transaction = undefined;
     this.participants = [];
   }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -111,7 +111,6 @@ export class Transaction extends events.EventEmitter {
       debug('[warning] removing __t has been failed');
       return this.resetTransaction();
     }
-    
     await this.transaction.remove();
     return this.resetTransaction();
   }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -101,8 +101,7 @@ export class Transaction extends events.EventEmitter {
   public async cancel(): Promise<void> {
     if (!this.transaction) return;
     if (this.transaction.state && this.transaction.state !== 'init') return;
-
-    await this.transaction.remove();
+ 
     try {
       await Bluebird.each(this.participants, async (participant) => {
         if (participant.doc.isNew) return participant.doc['__t'] = undefined;
@@ -110,8 +109,14 @@ export class Transaction extends events.EventEmitter {
       });
     } catch (e) {
       debug('[warning] removing __t has been failed');
+      return this.resetTransaction();
     }
+    
+    await this.transaction.remove();
+    return this.resetTransaction();
+  }
 
+  private async resetTransaction(): Promise<void> {
     this.transaction = undefined;
     this.participants = [];
   }


### PR DESCRIPTION
transaction cancel 시점에서 예외 사항이 발생할 경우
transcation document만 제거되고 participants의 _t는 제거되지 않을 가능성이 있다.

participants update에서 error가 발생할 경우 transaction의 document를 제거하지 않는다.
제거되지 않을 경우 resolvePreviousTransaction을 통해 처리된다.
최초 participant가 불릴 때 해당 transcation은 cancel 상태로 변경되고
그 이후 무시된다.

canceled 상태를 갖는 transaction document는 제거되지 않고 남아 있다.
향후 해당 document에 대해서 처리 필요