### PR TITLE
fix: happend writelock at recommit fail

### DIFF
--- a/src/spec/transaction-spec.ts
+++ b/src/spec/transaction-spec.ts
@@ -29,12 +29,6 @@ const debug = _debug('transaction:test');
 const conn: mongoose.Connection = mongoose.connection;
 
 describe('Transaction-static', () => {
-  it('should throw by use of begin() before initialize', spec(async () => {
-    let tx;
-    tx = new Transaction();
-    // await tx.begin();
-    // this will process down
-  }));
   it('should not allow an unique index', spec(async () => {
     expect(() => {
       new mongoose.Schema({ name: String }).index('name', {unique: true}).plugin(plugin);

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -180,6 +180,7 @@ export class Transaction extends events.EventEmitter {
     } catch (err) {
       // 하나라도 실패하면 pending 상태로 recommit 처리된다.
       debug('Fails to save whole transactions but they will be saved', err);
+      throw err;
     }
   }
 


### PR DESCRIPTION
If an error occurs at 'recommit', thrown 'writelock message' error message.

If an error occurs in a transaction, it must be throw the corresponding error.