### PR TITLE
fix: build error http://apseo-stt01:2000/job/mongoose-transaction-plu…

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "dependencies": {
         "bluebird": "^3.4.1",
         "debug": "^2.2.0",
-        "lodash": "^4.14.1",
+        "lodash": "^4.16.1",
         "mongoose": "^4.5.8"
     },
     "devDependencies": {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -279,10 +279,10 @@ export class Transaction extends events.EventEmitter {
   public async findOne<T extends mongoose.Document>(model: mongoose.Model<T>, cond: Object, fields?: Object, options?: Object): Promise<T> {
     if (!this.transaction) throw new Error('Could not find any transaction');
 
-    const p = _.find(this.participants, p => {
+    const withCond = _.find(this.participants, p => {
       return p.model === model && JSON.stringify(cond) === JSON.stringify(p.cond);
     });
-    if (p && p.doc) return p.doc as T;
+    if (withCond && withCond.doc) return withCond.doc as T;
 
     if (!options) options = { retrycount: RETRYCOUNT };
     if (options['retrycount'] === undefined) {
@@ -311,10 +311,10 @@ export class Transaction extends events.EventEmitter {
     }
     if (!doc) return;
 
-    const withSameId = _.find(this.participants, p => {
-      return p.model === model && p.doc._id.equals(doc._id);
+    const withSameId: IParticipant = _.find(this.participants, p => {
+      return p.model === model && (p.doc._id.equals(doc._id) as boolean);
     });
-    if (withSameId) return withSameId.doc as T;
+    if (withSameId && withSameId.doc) return withSameId.doc as T;
 
     this.participants.push({op: 'update', doc: doc, model: model, cond: cond});
     return doc;


### PR DESCRIPTION
http://apseo-stt01:2000/job/mongoose-transaction-plugin/48/console

00:09:22 > mongoose-transaction-plugin@1.5.0-dev build /app
00:09:22 > gulp build
00:09:22 
00:09:24 [15:09:24] Using gulpfile /app/gulpfile.js
00:09:24 [15:09:24] Starting 'build'...
00:09:30 [91m{ Error: Command failed: tsc -p /app
00:09:30 
00:09:30     at ChildProcess.exithandler (child_process.js:206:12)
00:09:30     at emitTwo (events.js:106:13)
00:09:30     at ChildProcess.emit (events.js:191:7)
00:09:30     at maybeClose (internal/child_process.js:877:16)
00:09:30     at Process.ChildProcess._handle.onexit (internal/child_process.js:226:5) killed: false, code: 2, signal: null, cmd: 'tsc -p /app' }
00:09:30 [0m[91m
00:09:30 [0msrc/transaction.ts(317,39): error TS2339: Property 'doc' does not exist on type 'number | ((...items: IParticipant[]) => number) | (() => IParticipant[]) | (<U>(callbackfn: (valu...'.
00:09:30   Property 'doc' does not exist on type 'number'.