### PR TITLE
feat: unique ShardKey

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -146,12 +146,14 @@ class PreFindOne {
 
 function ensureNoUnique(schema) {
   const indexes = schema.indexes();
+  const shardKey = schema.options.shardKey && Object.keys(schema.options.shardKey)[0];
   indexes.forEach(([name, options]) => {
     if (options && options.unique) {
       if (typeof name === 'object') {
         name = Object.keys(name)[0];
       }
-      throw new Error(`Transaction doesn't support an unique index (${name})`);
+      if (name !== shardKey)
+        throw new Error(`Transaction doesn't support an unique index (${name}) shardKey (${shardKey})`);
     }
   });
 }

--- a/src/spec/transaction-spec.ts
+++ b/src/spec/transaction-spec.ts
@@ -34,19 +34,19 @@ describe('Transaction-static', () => {
   it('should not allow an unique index', spec(async () => {
     expect(() => {
       new mongoose.Schema({ name: String }).index('name', {unique: true}).plugin(plugin);
-    }).toThrowError(`Transaction doesn't support an unique index (name)`);
+    }).toThrowError(`Transaction doesn't support an unique index (name) shardKey (null)`);
 
     expect(() => {
       new mongoose.Schema({ type: { type: Number, index: true, unique: true } }).plugin(plugin);
-    }).toThrowError(`Transaction doesn't support an unique index (type)`);
+    }).toThrowError(`Transaction doesn't support an unique index (type) shardKey (null)`);
 
     expect(() => {
       new mongoose.Schema({ type: { type: Number, index: true } }).plugin(plugin);
-    }).not.toThrowError(`Transaction doesn't support an unique index (type)`);
+    }).not.toThrowError(`Transaction doesn't support an unique index (type) shardKey (null)`);
 
     expect(() => {
       new mongoose.Schema({ name: String }).plugin(plugin).index('name', {unique: true});
-    }).toThrowError(`Transaction doesn't support an unique index (name)`);
+    }).toThrowError(`Transaction doesn't support an unique index (name) shardKey (null)`);
   }));
 });
 
@@ -283,6 +283,8 @@ describe('Transaction', () => {
     oldTransaction.history.push({
       col: TestPlayer.collection.name,
       oid: ekim._id,
+      shardKeyName: 'name',
+      shardKey: ekim.name,
       op: 'update',
       query: JSON.stringify({ $set: { money: 1000 } })
     });


### PR DESCRIPTION
The shard key can be used as a unique key.

At the shard environment, Shard-Key must in a condition.
However, Shard-Key cannot always be unique, Shard-Key alone cannot identify the Document.
The transaction should check `oid` and `Shard-Key` Value together.